### PR TITLE
py-asn1-modules: port abandoned

### DIFF
--- a/python/py-asn1-modules/Portfile
+++ b/python/py-asn1-modules/Portfile
@@ -8,7 +8,7 @@ version             0.2.5
 revision            0
 categories-append   devel crypto
 license             BSD
-maintainers         {eds.org:hans @eighthave} openmaintainer
+maintainers         nomaintainer
 
 description         A collection of ASN.1-based protocols modules.
 


### PR DESCRIPTION
Closes: https://trac.macports.org/ticket/58649

#### Description



###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL?
<!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
