### PR TITLE
commons-lang3: update to 3.11

### DIFF
--- a/java/commons-lang3/Portfile
+++ b/java/commons-lang3/Portfile
@@ -2,7 +2,7 @@ PortSystem 1.0
 PortGroup           java 1.0
 
 name                commons-lang3
-version             3.9
+version             3.11
 
 categories          java
 license             Apache-2
@@ -23,15 +23,13 @@ homepage            https://commons.apache.org/lang/
 distname            ${name}-${version}-src
 master_sites        apache:commons/lang/source/
 
-checksums           rmd160  c63c683570ae7a1391434b7e238c2358cb63380b \
-                    sha256  66415e0d1c843b04c61dea6b7e7e85a8f1469eaeb1174241622650aff7728e68 \
-                    size    987753
+checksums           rmd160  d622a496720e0a191a9cfbcccaca0e69ed47c47c \
+                    sha256  b99459133bf215caf65d571a9445dea495dda370dc9ff50f2818f381330e1531 \
+                    size    1054329
 
-# Currently has issues building on later JDK versions,
-# see https://github.com/macports/macports-ports/pull/4925#issuecomment-519172241
-#java.version       1.8+
-java.version        1.8
-java.fallback       openjdk8
+java.version        1.8+
+# Use latest LTS Java as fallback
+java.fallback       openjdk11
 
 depends_build       bin:mvn3:maven3
                 


### PR DESCRIPTION
Allow building with later Java versions: issue in JDK 11+ was fixed
Use latest LTS Java as fallback

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
