### PR TITLE
gdb: cleanup compiler.blacklist

### DIFF
--- a/devel/gdb/Portfile
+++ b/devel/gdb/Portfile
@@ -53,10 +53,6 @@ depends_lib     port:boehmgc \
 compiler.blacklist      {clang < 601}
 compiler.thread_local_storage \
                         yes
-# Work around thread local compiler selection bug. Remove after
-# https://github.com/macports/macports-base/pull/161 is released.
-compiler.blacklist-append \
-                        {clang < 800}
 
 # Needs C++11; halfway redundant due to the blacklist above, but make sure selected
 # compiler supports the standard - getting rid of old Apple GCC versions and the like?


### PR DESCRIPTION
macports-base#161 is included in 2.6.3

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
