### PR TITLE
qt6: Tcl syntax adjustment

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -1084,7 +1084,7 @@ foreach {sql_names sql_info} [array get sql_plugins] {
                 configure.args-append                                              \
                     [subst -D${dbms}_INCLUDE_DIR=\"[lindex ${variant_info} 2]\"]   \
                     [subst -DCMAKE_INCLUDE_PATH=\"[lindex ${variant_info} 2]\"]    \
-                    [subst -D${dbms}_LIBRARY=\"[lindex ${variant_info} 3]/[lindex ${variant_info} 4]"] \
+                    [subst -D${dbms}_LIBRARY=\"[lindex ${variant_info} 3]/[lindex ${variant_info} 4]\"] \
                     [subst -DCMAKE_LIBRARY_PATH=\"[lindex ${variant_info} 3]\"]
             }
         }


### PR DESCRIPTION
For consistency and to avoid syntax highlighter bug
(vscode, atom dashtcl)

[skip ci]