### PR TITLE
qt6-qtbase: revbump

### DIFF
--- a/aqua/qt6/Portfile
+++ b/aqua/qt6/Portfile
@@ -106,7 +106,7 @@ array set modules {
          "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 2"
         "License: "
     }
     qtsvg {


### PR DESCRIPTION
Needed because debfb6c2ad44 affected installed files.
See: https://trac.macports.org/ticket/67980

[skip ci]